### PR TITLE
アーカイブ機能を改修

### DIFF
--- a/daug/__init__.py
+++ b/daug/__init__.py
@@ -1,1 +1,1 @@
-from Daug.extension import *
+from Daug.extension import *  # noqa: F401, F403

--- a/daug/cogs/__init__.py
+++ b/daug/cogs/__init__.py
@@ -1,1 +1,1 @@
-from Daug.cogs import *
+from Daug.cogs import *  # noqa: F401, F403

--- a/daug/cogs/channels.py
+++ b/daug/cogs/channels.py
@@ -2,7 +2,6 @@ import io
 import discord
 from time import time
 from discord.ext import commands
-from dispander import compose_embed
 
 
 def compose_channel_tree(guild):

--- a/daug/cogs/functions/__init__.py
+++ b/daug/cogs/functions/__init__.py
@@ -1,1 +1,1 @@
-from Daug.cogs.functions import *
+from Daug.cogs.functions import *  # noqa: F401, F403


### PR DESCRIPTION
・「ARCHIVEカテゴリ内」ではない場合は、ARCHIVEカテゴリに移動するように
・ARCHIVEカテゴリへの移動は誰でも行えるように
・ログサーバーへの転送は「ARCHIVEカテゴリ内」かつ「チャンネル管理権限持ち」のみに
・「/archive」コマンドまたは🚫リアクションでアーカイブ操作を行う仕様は変更なし